### PR TITLE
Replaced true and false with 1 and 0, respectively, in path_condition…

### DIFF
--- a/approximable.py
+++ b/approximable.py
@@ -301,12 +301,15 @@ class Approximable(object):
             path_condition_with_error = path_condition_with_error.replace(">> 0", "")
             path_condition_with_error = path_condition_with_error.replace(">> ", ">> (int)")
             path_condition_with_error = path_condition_with_error.replace("<< ", "<< (int)")
+            path_condition_with_error = path_condition_with_error.replace("true", "1");
+            path_condition_with_error = path_condition_with_error.replace("false", "0");
         if(not path_condition_without_error == ' '):
             path_condition_without_error = path_condition_without_error.replace(" = ", " == ")
             path_condition_without_error = path_condition_without_error.replace(">> 0", "")
             path_condition_without_error = path_condition_without_error.replace(">> ", ">> (int)")
             path_condition_without_error = path_condition_without_error.replace("<< ", "<< (int)")
-
+            path_condition_without_error = path_condition_without_error.replace("true", "1");
+            path_condition_without_error = path_condition_without_error.replace("false", "0");
         #build C function to check satisfiability of path conditions with and without error
         pc_without_error_func = "int without_error() {\n float scaling = 1.0;"
         for var in input_variables:


### PR DESCRIPTION
…_with_error in approximable.py.

`True` and `false` constants in the path condition may occur when we ignore feasibility checking. They need to be replaced with respectively 1 and 0 in the C program.